### PR TITLE
# v11.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v11.1.7
+# New Features
+- Backpack Helpers (Requires Zhell's Backpack Manager)
+  - Added a one-click mechanism for creating a backpack actor and setting the permissions.
+  - Added a Transfer Backpack mechanism to give a backpack with all its contents to another player.
+  - Added automatic permission synchronization between a player and their backpacks.  
 # v11.1.6
 # New Features
 - Documentation

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Grab them [HERE](/misc/fred_custom_effects.json "download").
 - **Weapons**
   - **Reload Ranged Weapon**: Allows you to select an equipped ranged weapon and reload it with any available ammo from your inventory.
 
+# Integrations
+- **Zhell's Backpack Manager**
+  - When viewing a backpack item sheet, you will see the SDND icon. Clicking it will either:
+    - Automatically create a backpack actor if none exists and assign it the permissions of the actor.
+    - Launch a dialog to transfer the backpack and all its contents to another player. 
+  - Automatic synchronization of Actor permissions to their backpack.
+    - When you update the permissions of an actor, it will automatically push the changes to their backpack actors.  (This is useful when assigning ownership to a player for botting purposes.)
+
 # Supported Class Features
 |Class|Feature|Compendium Feature|Cast or Use Macro|Required NPC|Comments|
 |---|---|---|---|---|---|

--- a/module.json
+++ b/module.json
@@ -25,7 +25,8 @@
 				"manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
 				"compatibility": {
 					"minimum": "2.4.0",
-					"verified": "2.4.0"
+					"verified": "2.4.0",
+					"maximum": "2.4.x"
 				}
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroud-dnd-helpers",
-  "version": "11.1.6",
+  "version": "11.1.7",
   "description": "Stroud DnD Helpers",
   "main": "module.json",
   "scripts": {

--- a/scripts/actors/actors.js
+++ b/scripts/actors/actors.js
@@ -2,8 +2,37 @@ import { sdndConstants } from "../constants.js";
 import { items } from "../items/items.js";
 import { gmFunctions } from "../gm/gmFunctions.js";
 import { sdndSettings } from "../settings.js";
+import { folders } from "../folders/folders.js";
+import { dialog } from "../dialog/dialog.js";
+
 export let actors = {
     "ensureActor": ensureActor
+}
+
+export function createItemHeaderButton(config, buttons) {
+    if (!game.modules.find(m => m.id === "backpack-manager")?.active ?? false) {
+        return;
+    }
+    if (config.object instanceof Item) {
+        var item = config.object;
+        if (!item.type == "backpack") {
+            return;
+        }
+        var containerActorUuid = item.getFlag("backpack-manager", "containerActorUuid");
+        var actorID = containerActorUuid?.split('.')?.pop() ?? '';
+        var containerActor = actorID ? game.actors.get(actorID) : null;
+        var createNew = true;
+        if (containerActorUuid && containerActor) {
+            createNew = false;
+        }
+        var label = sdndSettings.HideTextOnActorSheet.getValue() ? '' : 'SDND';
+        buttons.unshift({
+            class: 'stroudDnD',
+            icon: 'fa-solid fa-dungeon',
+            label: label,
+            onclick: () => createNew ? createBackpack(item) : transferBackpack(item)
+        });
+    }
 }
 
 export function createActorHeaderButton(config, buttons) {
@@ -12,7 +41,7 @@ export function createActorHeaderButton(config, buttons) {
         if (!overrideableItems || overrideableItems.length == 0) {
             return;
         }
-        var label = sdndSettings.HideTextOnActorSheet.getValue() ? '' : 'SDND'; 
+        var label = sdndSettings.HideTextOnActorSheet.getValue() ? '' : 'SDND';
         buttons.unshift({
             class: 'stroudDnD',
             icon: 'fa-solid fa-dungeon',
@@ -20,6 +49,42 @@ export function createActorHeaderButton(config, buttons) {
             onclick: () => actorConfig(config.object)
         });
     }
+}
+
+export function syncBackpackPermissions(actor, updates, mode, updateUserId) {
+    if (!game.modules.find(m => m.id === "backpack-manager")?.active ?? false) {
+        return;
+    }
+    const playerFolder = sdndSettings.ActivePlayersFolder.getValue();
+    if (!(actor.folder?.name === playerFolder && updates['ownership'])) {
+        return;
+    }
+    var backPackIds = actor?.items
+        .filter(i => i.type === "backpack" && i.flags["backpack-manager"]?.containerActorUuid)
+        .map(i => i.getFlag("backpack-manager", "containerActorUuid").split('.')?.pop());
+    for (let backpackId of backPackIds) {
+        let backpack = game.actors.get(backpackId);
+        if (!backpack) {
+            continue;
+        }
+        var ownership = syncPermissions(backpack.ownership, updates['ownership']);
+        backpack.update({ "ownership": ownership });
+    }
+}
+
+
+// set current permission to defaults and overwrite with new permissions
+function syncPermissions(oldPermissions, newPermissions) {
+    let newOwnership = duplicate(newPermissions);
+    newOwnership['default'] = CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE;
+    var ownership = duplicate(oldPermissions);
+    for (let owner in ownership) {
+        ownership[owner] = CONST.DOCUMENT_OWNERSHIP_LEVELS.INHERIT;
+    }
+    for (let newOwner in newOwnership) {
+        ownership[newOwner] = newOwnership[newOwner];
+    }
+    return ownership;
 }
 
 function getOverrideableItemsFromActor(actorDocument) {
@@ -84,7 +149,7 @@ async function overrideSpells(actor, spells) {
     ui.notifications.info(`Number of spells replaced: ${spells.length}.`);
 }
 
-async function getReplacementFromCompendium(spell){
+async function getReplacementFromCompendium(spell) {
     let pack = "";
     switch (spell.type) {
         case "feat":
@@ -98,6 +163,59 @@ async function getReplacementFromCompendium(spell){
     }
     return await items.getItemFromCompendium(pack, spell.name, false, null);
 }
+
+async function createBackpack(item) {
+    if (!(item.type === 'backpack')) {
+        ui.notifications.info('This feature must be used on an item of type backpack!');
+        return;
+    }
+    var backpacksFolder = await folders.ensureFolder(sdndSettings.BackpacksFolder.getValue(), "Actor");
+    let ownership = syncPermissions({}, item?.parent?.ownership);
+    let backpack = await Actor.create({
+        'name': `${item.name}`,
+        'type': "npc",
+        'img': item.img,
+        'ownership': ownership,
+        'folder': backpacksFolder.id
+    });
+
+    item.setFlag("backpack-manager", "containerActorUuid", backpack.uuid);
+    ui.notifications.notify(`Managed backpack created for ${item.name}.`);
+}
+
+async function transferBackpack(item) {
+    if (!(item.type === 'backpack')) {
+        ui.notifications.info('This feature must be used on an item of type backpack!');
+        return;
+    }
+    const playersFolderName = sdndSettings.ActivePlayersFolder.getValue();
+    let currentOwner = item.parent;
+    let players = canvas.scene.tokens
+        .filter((token) => token.actor && token.actor?.id != currentOwner.id && token.actor?.folder?.name == playersFolderName)
+        .map(t => t.actor).sort(items.sortByName);
+    if (players.length == 0) {
+        ui.notifications.notify('There are no player tokens in this scene.');
+        return;
+    }
+    var targetPlayerId = await dialog.createButtonDialog(`Transfer ${item.name} to New Player`, players.map(p => ({ "label": p.name, "value": p.id })), 'column');
+    if (!targetPlayerId) {
+        return;
+    }
+    var targetPlayer = await game.actors.get(targetPlayerId);
+    let itemData = duplicate(item);
+    await currentOwner.deleteEmbeddedDocuments("Item", [item.id]);
+    await targetPlayer.createEmbeddedDocuments("Item", [itemData]);
+    var containerActorUuid = item.getFlag("backpack-manager", "containerActorUuid");
+    var actorID = containerActorUuid?.split('.')?.pop() ?? '';
+    var containerActor = actorID ? game.actors.get(actorID) : null;
+    if (!containerActor) {
+        return;
+    }
+    let ownership = syncPermissions(containerActor.ownership, targetPlayer.ownership);
+    await containerActor.update({ "ownership": ownership });
+    ui.notifications.notify(`${item.name} transferred to ${targetPlayer.name}.`);
+}
+
 
 async function promptForSpellOverrides(actor, overrideableItems, overriddenItems) {
     let options = overrideableItems.map(i => `<input type="checkbox" id="${i.id}" name="${i.id}" value="${i.id}">
@@ -119,7 +237,7 @@ async function promptForSpellOverrides(actor, overrideableItems, overriddenItems
                 callback: (html) => {
                     let selectedSpells = [];
                     overrideableItems.forEach(element => {
-                        if (html.find(`#${element.id}`).is(`:checked`)){
+                        if (html.find(`#${element.id}`).is(`:checked`)) {
                             selectedSpells.push(element);
                         }
                     });
@@ -137,4 +255,10 @@ async function promptForSpellOverrides(actor, overrideableItems, overriddenItems
         },
         default: "yes"
     }, { width: 500 }).render(true);
+}
+
+async function promptForTargetActor(item) {
+    debugger;
+
+
 }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,5 +1,5 @@
 import { calendar } from './calendar/calendar.js';
-import { createActorHeaderButton } from './actors/actors.js';
+import { createActorHeaderButton, createItemHeaderButton, syncBackpackPermissions } from './actors/actors.js';
 import { chat } from './chat/chat.js';
 import { combat } from './combat.js';
 import { gmFunctions } from './gm/gmFunctions.js';
@@ -19,7 +19,7 @@ import { macros } from './macros/macros.js';
 import { utility } from './utility/utility.js';
 
 import { hooks } from './hooks.js';
-//CONFIG.debug.hooks = true;
+// CONFIG.debug.hooks = true;
 
 export let socket;
 
@@ -35,6 +35,10 @@ Hooks.once('ready', async function() {
 	sdndSettings.registerSettings();
 	if (game.user?.isGM) {
 		Hooks.on('getActorSheet5eHeaderButtons', createActorHeaderButton);
+		if (game.modules.find(m => m.id === "backpack-manager")?.active ?? false) {
+			Hooks.on('getItemSheet5eHeaderButtons', createItemHeaderButton);
+			Hooks.on('updateActor', syncBackpackPermissions);
+		}
 	}
 	console.log("Loaded Stroud's DnD Helpers");
 });

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,4 +1,5 @@
 import { sdndConstants } from "./constants.js";
+import { folders } from "./folders/folders.js";
 
 export let sdndSettings = {
 	'registerSettings': function _registerSettings() {
@@ -77,7 +78,24 @@ export let sdndSettings = {
 			'default': false
 		},
 		'getValue': () =>  getModuleSettingValue('HideTextOnActorSheet')
-	}
+	},
+	'BackpacksFolder': {
+		'config' : {
+			'name': 'Backpacks Folder',
+			'hint': 'Used in conjunction with Backpacks Manager, this is where your backpacks should be created.',
+			'scope': 'world',
+			'config': true,
+			'type': String,
+			'default': 'Managed Backpacks'
+		},
+		'getValue': () => {
+			let folder = getModuleSettingValue('BackpacksFolder');
+			if (!folder || folder.length == 0) {
+				folder = 'Managed Backpacks';
+			}				
+			return folder;
+		} 
+	},
 };
 
 function getModuleSettingValue(settingName) {

--- a/src/packs/sdnd-documentation/SDND_Helpers_Documentation_MhrYh2XWhgfBnUOt.json
+++ b/src/packs/sdnd-documentation/SDND_Helpers_Documentation_MhrYh2XWhgfBnUOt.json
@@ -141,6 +141,41 @@
         "lastModifiedBy": "6yhz13iFYYklKtgA"
       },
       "_key": "!journal.pages!MhrYh2XWhgfBnUOt.qtieQHGvirSF9ZsV"
+    },
+    {
+      "sort": 25000,
+      "name": "Backpack Helpers",
+      "type": "text",
+      "_id": "nK2bj8d4WYNeJKXt",
+      "title": {
+        "show": true,
+        "level": 1
+      },
+      "image": {},
+      "text": {
+        "format": 1,
+        "content": "<h2>Description</h2><p>This works in conjunction with <a href=\"https://foundryvtt.com/packages/backpack-manager\" title=\"Zhell's Backpack Manager\">Zhell's Backpack Manager</a>.  When you open an item of type backpack, the SDND icon will be displayed.  When clicked, the icon will create a managed backpack if none exists or it will render a dialog allowing the backpack to be transferred to another character.</p><h2>Create Backpack</h2><ul><li><p>A backpack actor of type NPC will be created under a folder called Managed Backpacks.</p></li><li><p>The backpack will inherit the permissions of the owner.</p></li></ul><h2>Transfer Backpack</h2><ul><li><p>You will be asked to select from a list of player characters in the scene.</p></li><li><p>The backpack will be transferred to the chosen player.</p></li><li><p>The permissions of the backpack will now be in sync with the new owner.</p></li></ul><h2>Backpack Synchronization</h2><p>When you edit the ownership permissions of an actor, SDND will automatically sync the changes to the player's backpacks. </p><p>(This is useful in the case where you want to assign temporary ownership to an additional player for the purposes of botting.)</p>"
+      },
+      "video": {
+        "controls": true,
+        "volume": 0.5
+      },
+      "src": null,
+      "system": {},
+      "ownership": {
+        "default": -1,
+        "6yhz13iFYYklKtgA": 3
+      },
+      "flags": {},
+      "_stats": {
+        "systemId": "dnd5e",
+        "systemVersion": "2.4.1",
+        "coreVersion": "11.315",
+        "createdTime": 1707002601775,
+        "modifiedTime": 1707003116547,
+        "lastModifiedBy": "6yhz13iFYYklKtgA"
+      },
+      "_key": "!journal.pages!MhrYh2XWhgfBnUOt.nK2bj8d4WYNeJKXt"
     }
   ],
   "folder": null,
@@ -156,7 +191,7 @@
     "systemVersion": "2.4.1",
     "coreVersion": "11.315",
     "createdTime": 1706538266394,
-    "modifiedTime": 1706804394440,
+    "modifiedTime": 1707003116547,
     "lastModifiedBy": "6yhz13iFYYklKtgA"
   },
   "_id": "MhrYh2XWhgfBnUOt",


### PR DESCRIPTION
# New Features
- Backpack Helpers (Requires Zhell's Backpack Manager)
  - Added a one-click mechanism for creating a backpack actor and setting the permissions.
  - Added a Transfer Backpack mechanism to give a backpack with all its contents to another player.
  - Added automatic permission synchronization between a player and their backpacks.