### PR TITLE
# v12.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v12.4.3
+# New Features 
+- Removing Player tokens from scenes
+  - Right-click on a folder to remove player tokens from all scenes recursively.  (You must first specify your player actor folder by right-clicking an actor folder and selecting the star.)
 # v12.4.2
 # New Features 
 - AdHoc Damage

--- a/languages/en.json
+++ b/languages/en.json
@@ -2,6 +2,7 @@
     "MODULE.hello": "hello",
     "sdnd.actor.folder.context.togglePlayer":  "Toggle Player Folder",
     "sdnd.scenes.folder.context.regenerateThumbs":  "Regenerate Thumbnails",
+    "sdnd.scenes.folder.context.removePlayerTokens":  "Remove Player Tokens",
     "sdnd.compendium.entry.context.exportThumbnails":  "Export Thumbnails",
     "sdnd.primary":  "Primary"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stroud-dnd-helpers",
-  "version": "12.4.1",
+  "version": "12.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stroud-dnd-helpers",
-      "version": "12.4.1",
+      "version": "12.4.2",
       "license": "MIT",
       "devDependencies": {
         "@foundryvtt/foundryvtt-cli": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stroud-dnd-helpers",
-  "version": "12.4.1",
+  "version": "12.4.2",
   "description": "Stroud DnD Helpers",
   "main": "module.json",
   "scripts": {

--- a/scripts/utility/scene.js
+++ b/scripts/utility/scene.js
@@ -1,3 +1,4 @@
+import { folders } from "../folders/folders.js";
 
 export let scene = {
     "rewireMonksActiveTiles": foundry.utils.debounce(_rewireMonksActiveTiles, 250),
@@ -42,7 +43,10 @@ export let scene = {
         }
         await Scene.updateDocuments(updates);
         return updates;
-    }
+    },
+    "getScenesByFolderId": function _getScenesByFolderId(folderId) {
+        return game.scenes.filter(s => folders.childOfFolder(s, folderId));
+    },
 };
 
 let exportCounters = {


### PR DESCRIPTION
# New Features
- Removing Player tokens from scenes
  - Right-click on a folder to remove player tokens from all scenes recursively.  (You must first specify your player actor folder by right-clicking an actor folder and selecting the star.)